### PR TITLE
Add Developer account + enable product + Granite 3.2 config

### DIFF
--- a/3scale/templates/apis.yaml
+++ b/3scale/templates/apis.yaml
@@ -42,6 +42,9 @@ spec:
   applicationPlans:
     standard:
       name: "Standard Plan"
+      {{- if .applicationPlans.standard.appsRequireApproval }}
+      appsRequireApproval: {{ .applicationPlans.standard.appsRequireApproval }}
+      {{- end }}
       published: true
 ---
 apiVersion: capabilities.3scale.net/v1beta1

--- a/3scale/templates/user.yaml
+++ b/3scale/templates/user.yaml
@@ -1,0 +1,34 @@
+{{- range .Values.user }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  namespace: {{ $.Values.namespace }}
+type: Opaque
+stringData:
+  username: {{ .name }}
+  password: openshift
+---
+apiVersion: capabilities.3scale.net/v1beta1
+kind: DeveloperAccount
+metadata:
+  name: {{ .name }}
+  namespace: {{ $.Values.namespace }}
+spec:
+  orgName: {{ .name }}
+---
+kind: DeveloperUser
+apiVersion: capabilities.3scale.net/v1beta1
+metadata:
+  name: {{ .name }}
+  namespace: {{ $.Values.namespace }}
+spec:
+  developerAccountRef:
+    name: {{ .name }}
+  email: user1@example.com
+  passwordCredentialsRef:
+    name: {{ .name }}
+  role: admin
+  username: {{ .name }}
+{{- end }}

--- a/3scale/values-apis-lb1816.yaml
+++ b/3scale/values-apis-lb1816.yaml
@@ -85,5 +85,13 @@ apis:
         pattern: "/v1/embeddings"
         metricMethodRef: embeddings
         increment: 1
+    applicationPlans:
+      standard:
+        name: "Standard Plan"
+        appsRequireApproval: "false"
+        published: "true"
+user:
+  - name: user1
+    email: user1@example.com
   # - name: other
   #   activeDocOpenAPIRef: https://unknown/openapi.json

--- a/3scale/values-apis-lb1816.yaml
+++ b/3scale/values-apis-lb1816.yaml
@@ -1,9 +1,9 @@
 
 apis:
-  - name: granite-8b-code-instruct
-    activeDocOpenAPIRef: https://raw.githubusercontent.com/redhat-gpte-devopsautomation/llm-aas/refs/heads/main/bootstrap/3scale/api_definitions/granite-8b-code-instruct.json
+  - name: granite-3dot2-8b-instruct
+    activeDocOpenAPIRef: https://github.com/redhat-gpte-devopsautomation/lb1816-summit-llm-aas/raw/refs/heads/main/bootstrap/3scale/api_definitions/granite-3dot2-8b-instruct.json
     backend:
-      privateBaseURL: http://granite-8b-code-instruct-128k-predictor.llm-hosting.svc.cluster.local:8080
+      privateBaseURL: http://granite-3dot2-8b-instruct-predictor.llm-hosting.svc.cluster.local:8080
       path: /
     deployment:
       apicastHosted:


### PR DESCRIPTION
Adds a Developer account to allow user1 to login in the 3Scale admin portal.
Make default Granite product self-subscribable.